### PR TITLE
Add host priviledges to dash

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
 
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:host])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:host, :first_name, :last_name])
   end
 
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,7 @@
 class PagesController < ApplicationController
-  
+
   def dashboard
     @bookings = Booking.where(user_id: current_user)
+    @rock = Rock.new
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,6 +4,14 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
+    <%= f.input :first_name,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "First Name" }%>
+    <%= f.input :last_name,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "Last Name" }%>
     <%= f.input :email,
                 required: true,
                 autofocus: true,

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -1,8 +1,55 @@
-<h1>Hooray we have dashboard</h1>
+
+<h2> Hello, <%= @current_user.first_name %> </h2>
+<% if @current_user.host %>
+
+<!--Add rock Button trigger modal -->
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#newRockModal">
+  Add a new rock!
+</button>
+
+
+
+
+
+
+<% else %>
+
+
+<% end %>
 
 <% @bookings.each do |booking| %>
-<div>
-<%= booking.start_time %>
-<%= link_to "Delete", booking_path(booking), class:"btn btn-danger", data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %>
-</div>
+  <div>
+    <%= booking.start_time %>
+    <%= link_to "Delete", booking_path(booking), class:"btn btn-danger", data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %>
+  </div>
 <% end %>
+
+
+
+<%# Modal to add a new rock %>
+
+
+<div class="modal fade" id="newRockModal" tabindex="-1" role="dialog" aria-labelledby="newRockModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <%= simple_form_for(@rock) do |f| %>
+        <div class="modal-header">
+            <h5 class="modal-title" id="newRockModalLabel">Modal title</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <%= f.input :rock_type %>
+            <%= f.input :daily_price %>
+            <%= f.input :description %>
+            <%= f.input :photo, as: :file %>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+            <%= f.submit "Add Rock" %>
+          </div>
+        </div>
+      <% end %>
+  </div>
+</div>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -1,55 +1,51 @@
 
 <h2> Hello, <%= @current_user.first_name %> </h2>
-<% if @current_user.host %>
+  <% if @current_user.host %>
 
-<!--Add rock Button trigger modal -->
-<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#newRockModal">
-  Add a new rock!
-</button>
+  <!--Add rock Button trigger modal -->
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addNewRock">
+      Add a new rock!
+    </button>
 
-
-
-
+  <% else %>
 
 
-<% else %>
+  <% end %>
 
-
-<% end %>
-
-<% @bookings.each do |booking| %>
-  <div>
-    <%= booking.start_time %>
-    <%= link_to "Delete", booking_path(booking), class:"btn btn-danger", data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %>
-  </div>
-<% end %>
+    <% @bookings.each do |booking| %>
+      <div>
+        <%= booking.start_time %>
+        <%= link_to "Delete", booking_path(booking), class:"btn btn-danger", data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %>
+      </div>
+    <% end %>
 
 
 
-<%# Modal to add a new rock %>
 
 
-<div class="modal fade" id="newRockModal" tabindex="-1" role="dialog" aria-labelledby="newRockModalLabel" aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
+
+
+
+  <!-- Modal to add new rock -->
+  <div class="modal fade" id="addNewRock" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="addNewRockLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
       <%= simple_form_for(@rock) do |f| %>
-        <div class="modal-header">
-            <h5 class="modal-title" id="newRockModalLabel">Modal title</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
+          <div class="modal-header">
+            <h1 class="modal-title fs-5" id="staticBackdropLabel">Add a new rock!</h1>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
-          <div class="modal-body">
-            <%= f.input :rock_type %>
-            <%= f.input :daily_price %>
-            <%= f.input :description %>
-            <%= f.input :photo, as: :file %>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            <%= f.submit "Add Rock" %>
-          </div>
-        </div>
+            <div class="modal-body">
+              <%= f.input :rock_type %>
+              <%= f.input :daily_price %>
+              <%= f.input :description %>
+              <%= f.input :photo, as: :file %>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+              <%= f.submit "Add Rock" %>
+            </div>
+      </div>
       <% end %>
+    </div>
   </div>
-</div>

--- a/app/views/partials/_navbar.html.erb
+++ b/app/views/partials/_navbar.html.erb
@@ -10,6 +10,9 @@
       </li>
     <% if current_user %>
       <li class="nav-item">
+        <%= link_to "Dashboard", dashboard_path, class: "nav-link" %>
+      </li>
+      <li class="nav-item">
         <%= link_to "Sign out", destroy_user_session_path, class: "nav-link", data: { turbo_method: :delete } %>
       </li>
     <% else %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema[7.0].define(version: 2023_10_28_022208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Hey guys,

I set up the logic to display the dashboard based on whether user is a host or not with a greeting message. I could only work with the add new rock on this one as that's all I had available since my last pull from master but when I pull down again I'll add the other actions that are now complete. So far when you sign in as a host you can trigger a 'add rock modal'.

<img width="1433" alt="image" src="https://github.com/aresnelis/rock_rental/assets/129151965/4b2c8d5f-0e2f-467a-a3af-7e4f290fd16e">
